### PR TITLE
adding ansible role with template and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,36 @@ wscat -c ws://<IP ADDRESS>:9000/api/ws/icon_dex
 
 Check for a `connected` response. If you receive any error, your websocket is not working right.
 
+### Ansible Deployment
+
+To use ansible to copy over the files and render the docker-compose.yml with the appropriate entries (keystore_name, 
+password, image, and network_name), run the following command. 
+
+```bash
+ansible all \
+-m include_role \
+-a name=`pwd` \
+--inventory='X.X.X.X,' \
+--user=ubuntu \
+--become-method=sudo \
+--become \
+--forks=5 \
+--extra-vars='{"network_name":"testnet","image":"iconloop/prep-node:1911121115x323d60-dev","keystore_path":"keystore","keystore_password":"XXXX"}' \
+--private-key='/home/<user>/.ssh/XXX' 
+```
+
+- To fully bootstrap an instance with this role, the other required roles and playbook can be found at github
+.com/insight-infrastructure/ansible-icon-prep or simply contact Rob from Insight. These roles include 
+	- disable-ipv6
+ 	- install-packages
+ 	- mount-volumes
+ 	- keystore 
+ 	- start-docker
+
+- This role doesn't copy over the keystore and assumes it is already there
+	- keystore_path can be set as the name of the keystore unless you use this role 
+- This requires an exact path for private key and comma in inventory
+
 ## Licence
 
 This project is licensed under the MIT license. For more information see LICENSE.md.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,1 @@
+network_name: "mainnet"

--- a/prep/nginx/nginx.conf
+++ b/prep/nginx/nginx.conf
@@ -25,7 +25,7 @@ http {
 
   server {
     listen 9000;
-    listen [::]:9000;
+    # listen [::]:9000;
 
     access_log /var/log/nginx/api_log combined;
     error_log /var/log/nginx/api_error_log error;
@@ -62,7 +62,7 @@ stream {
 
   server {
     listen 7100;
-    listen [::]:7100;
+    # listen [::]:7100;
 
     access_log /var/log/nginx/grpc_log grpc_log;
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: "Create data directory"
+  file:
+    path: /home/ubuntu/data
+    mode: '0755'
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+
+- name: "Create cert directory"
+  file:
+    path: /home/ubuntu/cert
+    mode: '0600'
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+
+- name: "Copy over nginx"
+  synchronize:
+    src: "{{ role_path }}/prep/nginx"
+    dest: /home/ubuntu/
+
+- name: "Render the docker-compose file"
+  template:
+    src: "docker-compose.yml"
+    dest: /home/ubuntu/docker-compose.yml
+    mode: '0700'
+    owner: "ubuntu"
+    group: "ubuntu"

--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3'
+services:
+     nginx:
+          depends_on:
+               - prep
+          image: 'nginx:1.17.3'
+          container_name: 'nginx'
+          volumes:
+               - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+               - ./nginx/access_lists/:/etc/nginx/access_lists/
+               - ./nginx/log/:/var/log/nginx/
+          ports:
+               - 9000:9000
+               - 7100:7100
+          external_links:
+               - prep
+          restart: always
+
+     prep:
+          image: '{{ image }}'
+          container_name: 'prep'
+          environment: {% if network_name == 'mainnet' %}
+
+               NETWORK_ENV: "mainnet"
+               LOG_OUTPUT_TYPE: "file"
+               SWITCH_BH_VERSION3: "10324749"
+               CERT_PATH: "/cert"
+               LOOPCHAIN_LOG_LEVEL: "DEBUG"
+               ICON_LOG_LEVEL: "DEBUG"
+               FASTEST_START: "yes"{% else %}
+
+               CERT_PATH: "/cert"
+               LOOPCHAIN_LOG_LEVEL: "DEBUG"
+               ICON_LOG_LEVEL: "DEBUG"
+               FASTEST_START: "yes"{% endif %}
+
+               PRIVATE_KEY_FILENAME: "{{ keystore_path | basename }}"
+               PRIVATE_PASSWORD: "{{ keystore_password }}"
+               {% if citizen_ip is defined %}ENDPOINT_URL: "{{ ("http://" + citizen_ip + ":9000") }}"{% endif %}
+
+          cap_add:
+               - SYS_TIME
+          volumes:
+               - ./data:/data
+               - ./cert:/cert
+          expose:
+               - '9000'
+               - '7100'
+          restart: always


### PR DESCRIPTION
This PR adds an ansible role that renders a template to deliver the docker-compose with the right values based on user input.  This is one role that I use in my set of playbooks at [insight-infrastructure/ansible-icon-prep](https://github.com/insight-infrastructure/ansible-icon-prep).  

If you like the idea of putting this configuration into an ansible role, then I can also get the other tasks needed to fully bootstrap the instance as an option based on setting a variable.  Let me know what you think. 