### PR TITLE
Adding conditional based on network and pinning image id based on network 

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -27,7 +27,7 @@ services:
                CERT_PATH: "/cert"
                LOOPCHAIN_LOG_LEVEL: "DEBUG"
                ICON_LOG_LEVEL: "DEBUG"
-               FASTEST_START: "yes"{% else %}
+               FASTEST_START: "yes"{% elif network_name == 'testnet' %}
 
                CERT_PATH: "/cert"
                LOOPCHAIN_LOG_LEVEL: "DEBUG"


### PR DESCRIPTION
This makes it more predictable what image will be running by only specifying the network.  When a new image is out we update `network_name` to get the right image and env vars. 